### PR TITLE
[what][bugfix][h264] 修复 more_rbsp_data 判断错误问题

### DIFF
--- a/H264Deserialize.cpp
+++ b/H264Deserialize.cpp
@@ -1115,7 +1115,6 @@ bool H264Deserialize::DeserializePpsSyntax(H26xBinaryReader::ptr br, H264PpsSynt
     // See aslo : ISO 14496/10(2020) - 7.3.2.2 Picture parameter set RBSP syntax
     try
     {
-        br->more_rbsp_data();
         br->UE(pps->pic_parameter_set_id);
         MPP_H26X_SYNTAXT_STRICT_CHECK(pps->pic_parameter_set_id >= 0 && pps->pic_parameter_set_id <= 255, "[sps] pic_parameter_set_id out of range", return false);
         br->UE(pps->seq_parameter_set_id);

--- a/H26xBinaryReader.cpp
+++ b/H26xBinaryReader.cpp
@@ -327,22 +327,30 @@ bool H26xBinaryReader::more_rbsp_data()
             }
             catch (...)
             {
-                // Hint : nothing to do
+                // Hint : 剩余长度不足 3 时可以进入此异常
+                _rbspEndByte = _reader->Tell();
             }
         }
         // 2 - 移除 rbsp_trailing_bits() 后的几个 zero byte (,如果存在的话)
         {
-            
-            uint8_t zeroByte = 0;
-            do
+            try
             {
-                U(8, zeroByte, true);
-                if (zeroByte == 0)
+                uint8_t zeroByte = 0;
+                do
                 {
-                    _reader->Seek(_reader->Tell() - 1);
-                    _rbspEndByte = _reader->Tell();
-                }
-            } while (zeroByte == 0);            
+                    U(8, zeroByte, true);
+                    if (zeroByte == 0)
+                    {
+                        _reader->Seek(_reader->Tell() - 1);
+                        _rbspEndByte = _reader->Tell();
+                    }
+                } while (zeroByte == 0);   
+            }
+            catch (...)
+            {
+                // Hint : 无可读数据进入此异常
+                // nothing to do
+            }
         }
         _reader->Seek(curPosByte);
         if (curBitPos != 8)


### PR DESCRIPTION
[why] ByteStreamNalUnit 模式下, 外部已经分包完成, 故无法找到下一个 start code

[how]
1. 正确处理异常